### PR TITLE
 Adding PowerShell script to auto-import 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Install
 
-Execute .reg file to create new session with colors, or edit .reg file and put the name of existing session as regedit path to change colors of your existing session.
+Execute .ps1 file to create new session with colors, or edit .ps1 file and put the name of existing session as regedit path to change colors of your existing session.
 
 If you use a PuTTY fork that supports portable session files (e.g. [PuTTY Tray](https://puttytray.goeswhere.com/)), open the session file in a text editor and replace the color values with the ones from [dracula.portable](dracula.portable).
 

--- a/dracula-putty.ps1
+++ b/dracula-putty.ps1
@@ -1,0 +1,27 @@
+$temppath = 'HKEY_USERS\' + $(whoami /user | findstr S-1 | % { $_.Split(" ") | Select -last 1 }) + '\Software\SimonTatham\PuTTY\Sessions\Dracula'
+$regpath = echo $temppath
+
+New-Item -Path Registry::$regpath -Force | Out-Null
+
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour0' -Value '248,248,242'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour1' -Value '248,248,242'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour2' -Value '40,42,54'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour3' -Value '40,42,54'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour4' -Value '248,248,242'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour5' -Value '98,114,164'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour6' -Value '68,71,90'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour7' -Value '40,42,54'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour8' -Value '255,85,85'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour9' -Value '255,109,102'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour10' -Value '80,250,123'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour11' -Value '90,247,142'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour12' -Value '241,250,140'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour13' -Value '244,249,157'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour14' -Value '202,169,250'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour15' -Value '202,169,250'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour16' -Value '255,121,198'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour17' -Value '255,146,208'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour18' -Value '139,233,253'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour19' -Value '154,237,254'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour20' -Value '248,248,242'
+Set-ItemProperty -Path Registry::$regpath -Name 'Colour21' -Value '255,255,255'


### PR DESCRIPTION
Hi! I noticed the .reg didn't import in the right registry path on my system. It seems my PuTTY sessions are stored in `HKEY_USERS\<SID>\Software\SimonTatham\PuTTY\Sessions\Dracula`, instead of `HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Dracula`. I therefore created a (quick and dirty) PS script to fetch the current user's SID, to import a new session with the theme colours in the right registry location.